### PR TITLE
Removes parsing of Gemfile to find use of MRI

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -10,7 +10,7 @@ import (
 
 //go:generate faux --interface Parser --output fakes/parser.go
 type Parser interface {
-	Parse(path string) (hasMri, hasPuma bool, err error)
+	Parse(path string) (hasPuma bool, err error)
 }
 
 type BuildPlanMetadata struct {
@@ -27,12 +27,12 @@ func Detect(gemfileParser Parser) packit.DetectFunc {
 			return packit.DetectResult{}, fmt.Errorf("failed to stat config.ru: %w", err)
 		}
 
-		hasMri, hasPuma, err := gemfileParser.Parse(filepath.Join(context.WorkingDir, "Gemfile"))
+		hasPuma, err := gemfileParser.Parse(filepath.Join(context.WorkingDir, "Gemfile"))
 		if err != nil {
 			return packit.DetectResult{}, fmt.Errorf("failed to parse Gemfile: %w", err)
 		}
 
-		if !hasMri || !hasPuma {
+		if !hasPuma {
 			return packit.DetectResult{}, packit.Fail
 		}
 

--- a/detect_test.go
+++ b/detect_test.go
@@ -48,7 +48,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 	context("when the Gemfile lists puma and mri", func() {
 		it.Before(func() {
 			gemfileParser.ParseCall.Returns.HasPuma = true
-			gemfileParser.ParseCall.Returns.HasMri = true
 		})
 		it("detects", func() {
 			result, err := detect(packit.DetectContext{
@@ -97,7 +96,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 	context("when the workingDir does not have a config.ru", func() {
 		it.Before(func() {
 			gemfileParser.ParseCall.Returns.HasPuma = true
-			gemfileParser.ParseCall.Returns.HasMri = true
+
 			Expect(os.Remove(filepath.Join(workingDir, "config.ru"))).To(Succeed())
 		})
 

--- a/fakes/parser.go
+++ b/fakes/parser.go
@@ -10,15 +10,14 @@ type Parser struct {
 			Path string
 		}
 		Returns struct {
-			HasMri  bool
 			HasPuma bool
 			Err     error
 		}
-		Stub func(string) (bool, bool, error)
+		Stub func(string) (bool, error)
 	}
 }
 
-func (f *Parser) Parse(param1 string) (bool, bool, error) {
+func (f *Parser) Parse(param1 string) (bool, error) {
 	f.ParseCall.Lock()
 	defer f.ParseCall.Unlock()
 	f.ParseCall.CallCount++
@@ -26,5 +25,5 @@ func (f *Parser) Parse(param1 string) (bool, bool, error) {
 	if f.ParseCall.Stub != nil {
 		return f.ParseCall.Stub(param1)
 	}
-	return f.ParseCall.Returns.HasMri, f.ParseCall.Returns.HasPuma, f.ParseCall.Returns.Err
+	return f.ParseCall.Returns.HasPuma, f.ParseCall.Returns.Err
 }

--- a/gemfile_parser.go
+++ b/gemfile_parser.go
@@ -13,33 +13,27 @@ func NewGemfileParser() GemfileParser {
 	return GemfileParser{}
 }
 
-func (p GemfileParser) Parse(path string) (bool, bool, error) {
+func (p GemfileParser) Parse(path string) (bool, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return false, false, nil
+			return false, nil
 		}
-		return false, false, fmt.Errorf("failed to parse Gemfile: %w", err)
+
+		return false, fmt.Errorf("failed to parse Gemfile: %w", err)
 	}
 	defer file.Close()
 
 	quotes := `["']`
-	mriRe := regexp.MustCompile(`^ruby .*`)
 	pumaRe := regexp.MustCompile(fmt.Sprintf(`^gem %spuma%s`, quotes, quotes))
-
-	hasMri := false
-	hasPuma := false
-
 	scanner := bufio.NewScanner(file)
+
 	for scanner.Scan() {
 		line := []byte(scanner.Text())
-		if hasMri == false {
-			hasMri = mriRe.Match(line)
-		}
-		if hasPuma == false {
-			hasPuma = pumaRe.Match(line)
+		if pumaRe.Match(line) {
+			return true, nil
 		}
 	}
 
-	return hasMri, hasPuma, nil
+	return false, nil
 }

--- a/gemfile_parser_test.go
+++ b/gemfile_parser_test.go
@@ -34,47 +34,28 @@ func testGemfileParser(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	context("Parse", func() {
-		context("when using puma and mri", func() {
+		context("when using puma", func() {
 			it("parses correctly", func() {
 				const GEMFILE_CONTENTS = `source 'https://rubygems.org'
-ruby '~> 2.0'
-
 gem 'puma'`
 
 				Expect(ioutil.WriteFile(path, []byte(GEMFILE_CONTENTS), 0644)).To(Succeed())
 
-				hasMri, hasPuma, err := parser.Parse(path)
+				hasPuma, err := parser.Parse(path)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(hasMri).To(Equal(true))
 				Expect(hasPuma).To(Equal(true))
 			})
 		})
 
 		context("when not using puma", func() {
 			it("parses correctly", func() {
-				const GEMFILE_CONTENTS = `source 'https://rubygems.org'
-ruby '~> 2.0'`
+				const GEMFILE_CONTENTS = `source 'https://rubygems.org'`
 
 				Expect(ioutil.WriteFile(path, []byte(GEMFILE_CONTENTS), 0644)).To(Succeed())
 
-				_, hasPuma, err := parser.Parse(path)
+				hasPuma, err := parser.Parse(path)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(hasPuma).To(Equal(false))
-			})
-		})
-
-		context("when not using mri", func() {
-			it("parses correctly", func() {
-				const GEMFILE_CONTENTS = `source 'https://rubygems.org'
-jruby '~> 2.0'
-
-gem 'puma'`
-
-				Expect(ioutil.WriteFile(path, []byte(GEMFILE_CONTENTS), 0644)).To(Succeed())
-
-				hasMri, _, err := parser.Parse(path)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(hasMri).To(Equal(false))
 			})
 		})
 
@@ -84,9 +65,8 @@ gem 'puma'`
 			})
 
 			it("returns all false", func() {
-				hasMri, hasPuma, err := parser.Parse(path)
+				hasPuma, err := parser.Parse(path)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(hasMri).To(Equal(false))
 				Expect(hasPuma).To(Equal(false))
 			})
 		})
@@ -98,7 +78,7 @@ gem 'puma'`
 				})
 
 				it("returns an error", func() {
-					_, _, err := parser.Parse(path)
+					_, err := parser.Parse(path)
 					Expect(err).To(HaveOccurred())
 					Expect(err).To(MatchError(ContainSubstring("failed to parse Gemfile:")))
 					Expect(err).To(MatchError(ContainSubstring("permission denied")))


### PR DESCRIPTION
There is no guarantee that the `ruby` directive will appear in a Gemfile. This means that, until we have support for other Ruby implementations, we should just assume MRI and require it in the detect phase rather than failing to detect.