### PR TITLE
Move main.go into run sub-package

### DIFF
--- a/build.go
+++ b/build.go
@@ -1,4 +1,4 @@
-package main
+package puma
 
 import (
 	"github.com/paketo-buildpacks/packit"

--- a/build_test.go
+++ b/build_test.go
@@ -1,4 +1,4 @@
-package main_test
+package puma_test
 
 import (
 	"bytes"
@@ -8,7 +8,7 @@ import (
 
 	"github.com/paketo-buildpacks/packit"
 	"github.com/paketo-buildpacks/packit/scribe"
-	main "github.com/paketo-community/puma"
+	"github.com/paketo-community/puma"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
@@ -40,7 +40,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		buffer = bytes.NewBuffer(nil)
 		logger := scribe.NewLogger(buffer)
 
-		build = main.Build(logger)
+		build = puma.Build(logger)
 	})
 
 	it.After(func() {

--- a/detect.go
+++ b/detect.go
@@ -1,4 +1,4 @@
-package main
+package puma
 
 import (
 	"fmt"

--- a/detect_test.go
+++ b/detect_test.go
@@ -1,4 +1,4 @@
-package main_test
+package puma_test
 
 import (
 	"errors"
@@ -9,7 +9,7 @@ import (
 	"io/ioutil"
 
 	"github.com/paketo-buildpacks/packit"
-	main "github.com/paketo-community/puma"
+	"github.com/paketo-community/puma"
 	"github.com/paketo-community/puma/fakes"
 	"github.com/sclevine/spec"
 
@@ -38,7 +38,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 		gemfileParser = &fakes.Parser{}
 
-		detect = main.Detect(gemfileParser)
+		detect = puma.Detect(gemfileParser)
 	})
 
 	it.After(func() {
@@ -59,19 +59,19 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 				Requires: []packit.BuildPlanRequirement{
 					{
 						Name: "gems",
-						Metadata: main.BuildPlanMetadata{
+						Metadata: puma.BuildPlanMetadata{
 							Launch: true,
 						},
 					},
 					{
 						Name: "bundler",
-						Metadata: main.BuildPlanMetadata{
+						Metadata: puma.BuildPlanMetadata{
 							Launch: true,
 						},
 					},
 					{
 						Name: "mri",
-						Metadata: main.BuildPlanMetadata{
+						Metadata: puma.BuildPlanMetadata{
 							Launch: true,
 						},
 					},

--- a/gemfile_parser.go
+++ b/gemfile_parser.go
@@ -1,4 +1,4 @@
-package main
+package puma
 
 import (
 	"bufio"

--- a/gemfile_parser_test.go
+++ b/gemfile_parser_test.go
@@ -1,14 +1,14 @@
-package main_test
+package puma_test
 
 import (
 	"io/ioutil"
 	"os"
 	"testing"
 
+	"github.com/paketo-community/puma"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
-	main "github.com/paketo-community/puma"
 )
 
 func testGemfileParser(t *testing.T, context spec.G, it spec.S) {
@@ -16,7 +16,7 @@ func testGemfileParser(t *testing.T, context spec.G, it spec.S) {
 		Expect = NewWithT(t).Expect
 
 		path   string
-		parser main.GemfileParser
+		parser puma.GemfileParser
 	)
 
 	it.Before(func() {
@@ -26,7 +26,7 @@ func testGemfileParser(t *testing.T, context spec.G, it spec.S) {
 
 		path = file.Name()
 
-		parser = main.NewGemfileParser()
+		parser = puma.NewGemfileParser()
 	})
 
 	it.After(func() {

--- a/init_test.go
+++ b/init_test.go
@@ -1,4 +1,4 @@
-package main_test
+package puma_test
 
 import (
 	"testing"

--- a/run/main.go
+++ b/run/main.go
@@ -5,14 +5,15 @@ import (
 
 	"github.com/paketo-buildpacks/packit"
 	"github.com/paketo-buildpacks/packit/scribe"
+	"github.com/paketo-community/puma"
 )
 
 func main() {
-	parser := NewGemfileParser()
+	parser := puma.NewGemfileParser()
 	logger := scribe.NewLogger(os.Stdout)
 
-	detect := Detect(parser)
-	build := Build(logger)
-
-	packit.Run(detect, build)
+	packit.Run(
+		puma.Detect(parser),
+		puma.Build(logger),
+	)
 }


### PR DESCRIPTION
This ensures that we don't have issues with importing `main` if that needs to happen.