### PR TITLE
Uses occam.Source to allow integration specs to run in parallel

### DIFF
--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -28,22 +28,22 @@ func TestIntegration(t *testing.T) {
 	Expect := NewWithT(t).Expect
 
 	root, err := filepath.Abs("./..")
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 
 	pumaBuildpack, err = dagger.PackageBuildpack(root)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 
 	// HACK: we need to fix dagger and the package.sh scripts so that this isn't required
 	pumaBuildpack = fmt.Sprintf("%s.tgz", pumaBuildpack)
 
 	mriBuildpack, err = dagger.GetLatestCommunityBuildpack("paketo-community", "mri")
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 
 	bundlerBuildpack, err = dagger.GetLatestCommunityBuildpack("paketo-community", "bundler")
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 
 	bundleInstallBuildpack, err = dagger.GetLatestCommunityBuildpack("paketo-community", "bundle-install")
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 
 	defer func() {
 		dagger.DeleteBuildpack(pumaBuildpack)

--- a/integration/simple_app_test.go
+++ b/integration/simple_app_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -33,7 +34,8 @@ func testSimpleApp(t *testing.T, context spec.G, it spec.S) {
 			image     occam.Image
 			container occam.Container
 
-			name string
+			name   string
+			source string
 		)
 
 		it.Before(func() {
@@ -46,15 +48,19 @@ func testSimpleApp(t *testing.T, context spec.G, it spec.S) {
 			Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
 			Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
 			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+			Expect(os.RemoveAll(source)).To(Succeed())
 		})
 
 		it("creates a working OCI image with a puma start command", func() {
 			var err error
+			source, err = occam.Source(filepath.Join("testdata", "simple_app"))
+			Expect(err).NotTo(HaveOccurred())
+
 			var logs fmt.Stringer
 			image, logs, err = pack.WithNoColor().Build.
 				WithBuildpacks(mriBuildpack, bundlerBuildpack, bundleInstallBuildpack, pumaBuildpack).
 				WithNoPull().
-				Execute(name, filepath.Join("testdata", "simple_app"))
+				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred(), logs.String())
 
 			container, err = docker.Container.Run.WithEnv(map[string]string{"PORT": "9292"}).Execute(image.ID)
@@ -73,7 +79,7 @@ func testSimpleApp(t *testing.T, context spec.G, it spec.S) {
 			Expect(string(content)).To(ContainSubstring("Hello world!"))
 
 			buildpackVersion, err := GetGitVersion()
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(logs).To(ContainLines(
 				fmt.Sprintf("Puma Buildpack %s", buildpackVersion),


### PR DESCRIPTION
occam.Source duplicates the source code directory and makes it unique by adding a file with unique random content.